### PR TITLE
Fix: #40 replace javafx pair with a custom record type for CommandService

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("java")
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("com.diffplug.spotless") version "7.0.2"
-    id("org.openjfx.javafxplugin") version "0.1.0"
 }
 
 group = "app.ciserver"
@@ -22,7 +21,6 @@ dependencies {
     implementation("org.thymeleaf:thymeleaf:3.1.3.RELEASE")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
     implementation("org.slf4j:slf4j-simple:2.0.16")
-    implementation("org.openjfx:javafx-base:21.0.2")
 }
 
 java {

--- a/src/main/java/app/ciserver/CommandService.java
+++ b/src/main/java/app/ciserver/CommandService.java
@@ -3,7 +3,6 @@ package app.ciserver;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import javafx.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +13,9 @@ import org.slf4j.LoggerFactory;
 public class CommandService {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(CommandService.class);
+
+	public record CommandResult(int exitCode, String output) {
+	}
 
 	/**
 	 * <b>DON'T USE THIS METHOD, IT IS PACKAGE-PRIVATE ONLY FOR TESTING</b>
@@ -41,7 +43,7 @@ public class CommandService {
 	 *            - String representation of command that should be executed.
 	 * @return - A pair consisting of the exit code and the ouput from the process.
 	 */
-	public Pair<Integer, String> runCommand(String[] command) {
+	public CommandResult runCommand(String[] command) {
 		// Create process from command
 		ProcessBuilder processBuilder = getProcessBuilder(command);
 		processBuilder.redirectErrorStream(true); // merge standard output and standard error streams.
@@ -68,7 +70,7 @@ public class CommandService {
 			LOGGER.error("Error while executing command '{}' : {}", String.join(" ", command), e.getMessage());
 		}
 
-		return new Pair<>(exitCode, output.toString());
+		return new CommandResult(exitCode, output.toString());
 
 	}
 }

--- a/src/test/java/app/ciserver/CommandServiceTest.java
+++ b/src/test/java/app/ciserver/CommandServiceTest.java
@@ -5,26 +5,10 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import javafx.util.Pair;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 class CommandServiceTest {
-	// private CommandService commandService;
-	// @BeforeEach
-	// void setUp() {
-	// commandService = new CommandService();
-	// }
-	// @Test
-	// public void validCommand() {
-	// String[] command = {"powershell.exe", "-Command", "ls"}; // Valid command.
-	// Pair<Integer, String> output = commandService.runCommand(command);
-	// int expectedExitCode = 0; // Should return with no errors.
-	// int actualExitCode = output.getKey(); // get the exitcode
-	// String actualString = output.getValue(); // get output string.
-	// assertEquals(expectedExitCode, actualExitCode);
-	// assertNotNull(actualString);
-	// }
 
 	static CommandService spiedCommandService;
 	static ProcessBuilder mockProcessBuilder;
@@ -48,7 +32,7 @@ class CommandServiceTest {
 
 		var result = spiedCommandService.runCommand(command);
 
-		assertEquals(new Pair<>(-1, ""), result);
+		assertEquals(new CommandService.CommandResult(-1, ""), result);
 	}
 
 	@Test
@@ -70,7 +54,7 @@ class CommandServiceTest {
 
 		verify(mockProcessBuilder).redirectErrorStream(true); // check that stderr is redirected to stdout
 
-		assertEquals(new Pair<>(2, output), result);
+		assertEquals(new CommandService.CommandResult(2, output), result);
 	}
 
 }


### PR DESCRIPTION
For CommandService.runCommand(), change return type from javafx pair to CommandResult custom record type. This allows us to remove the javafx dependency that causes unnecessary problems + removed unwanted commented out code

Closes #40 