### PR TITLE
#42 add TestRunModel and unit tests for serialization/deserialization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("org.thymeleaf:thymeleaf:3.1.3.RELEASE")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
     implementation("org.slf4j:slf4j-simple:2.0.16")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation("org.thymeleaf:thymeleaf:3.1.3.RELEASE")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
     implementation("org.slf4j:slf4j-simple:2.0.16")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0")
 }
 
 java {

--- a/src/main/java/app/ciserver/TestRunModel.java
+++ b/src/main/java/app/ciserver/TestRunModel.java
@@ -1,10 +1,10 @@
 package app.ciserver;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDateTime;
+import java.util.Date;
 
 public record TestRunModel(
-		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy HH:mm:ss", timezone = "Europe/Stockholm") LocalDateTime timestamp,
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy HH:mm:ss", timezone = "Europe/Stockholm") Date timestamp,
 		String status, // "success", "failure", "error"
 		String commitSHA, String branchName, String pusherName, String buildLogs) {
 }

--- a/src/main/java/app/ciserver/TestRunModel.java
+++ b/src/main/java/app/ciserver/TestRunModel.java
@@ -1,0 +1,10 @@
+package app.ciserver;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+public record TestRunModel(
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy HH:mm:ss", timezone = "Europe/Stockholm") LocalDateTime timestamp,
+		String status, // "success", "failure", "error"
+		String commitSHA, String branchName, String pusherName, String buildLogs) {
+}

--- a/src/test/java/app/ciserver/TestRunModelTest.java
+++ b/src/test/java/app/ciserver/TestRunModelTest.java
@@ -4,15 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import org.junit.jupiter.api.Test;
 
 public class TestRunModelTest {
 	@Test
-	public void deserializeNoError() throws IOException {
+	public void deserializeNoError() throws IOException, Exception {
 		// Correct JSON matching TestRunModel structure
 		String json = """
 				{
@@ -26,8 +25,10 @@ public class TestRunModelTest {
 				""";
 
 		// Deserialize JSON into TestRunModel object
-		TestRunModel testRun = new ObjectMapper().registerModule(new JavaTimeModule()).readValue(json,
-				TestRunModel.class);
+		TestRunModel testRun = new ObjectMapper().readValue(json, TestRunModel.class);
+
+		SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
+		Date expectedTimestamp = dateFormat.parse("11-02-2025 15:30:45");
 
 		// Assertions to verify all fields are correctly set
 		assertNotNull(testRun);
@@ -36,18 +37,17 @@ public class TestRunModelTest {
 		assertEquals("feature-branch", testRun.branchName());
 		assertEquals("JohnDoe", testRun.pusherName());
 		assertEquals("BUILD SUCCESSFUL Total time: 30s", testRun.buildLogs());
-
-		LocalDateTime expectedTimestamp = LocalDateTime.parse("11-02-2025 15:30:45",
-				DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss"));
-
 		assertEquals(expectedTimestamp, testRun.timestamp());
 	}
 
 	@Test
 	public void testTestRunModelSerialization() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
+		Date timestamp = dateFormat.parse("11-02-2025 15:30:45");
+
 		// Create an instance of TestRunModel
-		TestRunModel testRun = new TestRunModel(LocalDateTime.of(2025, 2, 11, 15, 30, 45), "success",
-				"a1b2c3d4e5f6g7h8i9j0", "feature-branch", "JohnDoe", "BUILD SUCCESSFUL Total time: 30s");
+		TestRunModel testRun = new TestRunModel(timestamp, "success", "a1b2c3d4e5f6g7h8i9j0", "feature-branch",
+				"JohnDoe", "BUILD SUCCESSFUL Total time: 30s");
 
 		// Expected JSON structure
 		String expectedJson = """
@@ -63,7 +63,6 @@ public class TestRunModelTest {
 
 		// Serialize to JSON
 		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.registerModule(new JavaTimeModule());
 		String json = objectMapper.writeValueAsString(testRun);
 
 		// Compare actual and expected JSON

--- a/src/test/java/app/ciserver/TestRunModelTest.java
+++ b/src/test/java/app/ciserver/TestRunModelTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 
 public class TestRunModelTest {
@@ -28,6 +29,7 @@ public class TestRunModelTest {
 		TestRunModel testRun = new ObjectMapper().readValue(json, TestRunModel.class);
 
 		SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
+		dateFormat.setTimeZone(TimeZone.getTimeZone("Europe/Stockholm"));
 		Date expectedTimestamp = dateFormat.parse("11-02-2025 15:30:45");
 
 		// Assertions to verify all fields are correctly set
@@ -43,6 +45,7 @@ public class TestRunModelTest {
 	@Test
 	public void testTestRunModelSerialization() throws Exception {
 		SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
+		dateFormat.setTimeZone(TimeZone.getTimeZone("Europe/Stockholm"));
 		Date timestamp = dateFormat.parse("11-02-2025 15:30:45");
 
 		// Create an instance of TestRunModel

--- a/src/test/java/app/ciserver/TestRunModelTest.java
+++ b/src/test/java/app/ciserver/TestRunModelTest.java
@@ -1,0 +1,72 @@
+package app.ciserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.Test;
+
+public class TestRunModelTest {
+	@Test
+	public void deserializeNoError() throws IOException {
+		// Correct JSON matching TestRunModel structure
+		String json = """
+				{
+				                "timestamp": "11-02-2025 15:30:45",
+				                "status": "success",
+				                "commitSHA": "a1b2c3d4e5f6g7h8i9j0",
+				                "branchName": "feature-branch",
+				                "pusherName": "JohnDoe",
+				                "buildLogs": "BUILD SUCCESSFUL Total time: 30s"
+				}
+				""";
+
+		// Deserialize JSON into TestRunModel object
+		TestRunModel testRun = new ObjectMapper().registerModule(new JavaTimeModule()).readValue(json,
+				TestRunModel.class);
+
+		// Assertions to verify all fields are correctly set
+		assertNotNull(testRun);
+		assertEquals("success", testRun.status());
+		assertEquals("a1b2c3d4e5f6g7h8i9j0", testRun.commitSHA());
+		assertEquals("feature-branch", testRun.branchName());
+		assertEquals("JohnDoe", testRun.pusherName());
+		assertEquals("BUILD SUCCESSFUL Total time: 30s", testRun.buildLogs());
+
+		LocalDateTime expectedTimestamp = LocalDateTime.parse("11-02-2025 15:30:45",
+				DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss"));
+
+		assertEquals(expectedTimestamp, testRun.timestamp());
+	}
+
+	@Test
+	public void testTestRunModelSerialization() throws Exception {
+		// Create an instance of TestRunModel
+		TestRunModel testRun = new TestRunModel(LocalDateTime.of(2025, 2, 11, 15, 30, 45), "success",
+				"a1b2c3d4e5f6g7h8i9j0", "feature-branch", "JohnDoe", "BUILD SUCCESSFUL Total time: 30s");
+
+		// Expected JSON structure
+		String expectedJson = """
+				{
+				    "timestamp": "11-02-2025 15:30:45",
+				    "status": "success",
+				    "commitSHA": "a1b2c3d4e5f6g7h8i9j0",
+				    "branchName": "feature-branch",
+				    "pusherName": "JohnDoe",
+				    "buildLogs": "BUILD SUCCESSFUL Total time: 30s"
+				}
+				""";
+
+		// Serialize to JSON
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		String json = objectMapper.writeValueAsString(testRun);
+
+		// Compare actual and expected JSON
+		assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(json));
+	}
+}


### PR DESCRIPTION
Implemented TestRunModel to store test run metadata, including timestamp, status, commit SHA, branch name, pusher name, and build logs.
Added `TestRunModelTest` to validate serialization and deserialization.

Closes #42
