### PR TITLE
Fix: #48 remove username field in PusherModen

### DIFF
--- a/src/main/java/app/ciserver/PusherModel.java
+++ b/src/main/java/app/ciserver/PusherModel.java
@@ -4,6 +4,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record PusherModel(@JsonProperty(required = true) String email, @JsonProperty(required = true) String name,
-		@JsonProperty(required = true) String username) {
+public record PusherModel(@JsonProperty(required = true) String email, @JsonProperty(required = true) String name) {
 }

--- a/src/test/java/app/ciserver/HookEventModelTest.java
+++ b/src/test/java/app/ciserver/HookEventModelTest.java
@@ -17,8 +17,7 @@ class HookEventModelTest {
 				    "ref": "refValue",
 				    "pusher": {
 				        "email": "emailValue",
-				        "name": "nameValue",
-				        "username": "usernameValue"
+				        "name": "nameValue"
 				    },
 				    "repository": {
 				    	"clone_url": "cloneUrlValue",
@@ -39,8 +38,7 @@ class HookEventModelTest {
 				    "ref": "refValue",
 				    "pusher": {
 				        "email": "emailValue",
-				        "name": "nameValue",
-				        "username": "usernameValue"
+				        "name": "nameValue"
 				    },
 				    "repository": {
 				    	"clone_url": "cloneUrlValue",

--- a/src/test/java/app/ciserver/NotificationServiceTest.java
+++ b/src/test/java/app/ciserver/NotificationServiceTest.java
@@ -20,7 +20,7 @@ class NotificationServiceTest {
 	@BeforeAll
 	static void testSetup() {
 		uriStub = "https://www.example.com";
-		pathParams = new HookEventModel("sha23", "ref", new PusherModel("silly@mail", "name", "username"),
+		pathParams = new HookEventModel("sha23", "ref", new PusherModel("silly@mail", "name"),
 				new RepositoryModel("cloneUrl", "FullName"));
 	}
 

--- a/src/test/java/app/ciserver/PusherModelTest.java
+++ b/src/test/java/app/ciserver/PusherModelTest.java
@@ -13,7 +13,6 @@ class PusherModelTest {
 		String json = """
 				    {
 						"name": "nameValue",
-						"username": "usernameValue",
 						"other": "otherValue"
 					}
 				""";
@@ -27,7 +26,6 @@ class PusherModelTest {
 				    {
 				        "email": "emailValue",
 						"name": "nameValue",
-						"username": "usernameValue",
 						"other": "otherValue"
 					}
 				""";
@@ -36,6 +34,5 @@ class PusherModelTest {
 
 		assertEquals("emailValue", pusher.email());
 		assertEquals("nameValue", pusher.name());
-		assertEquals("usernameValue", pusher.username());
 	}
 }


### PR DESCRIPTION
Removed the username field because it is not present in the webhook data.

Closes #48