### PR TITLE
Fix: #58 persistence service creates folder when saving

### DIFF
--- a/src/main/java/app/ciserver/TestRunPersistenceService.java
+++ b/src/main/java/app/ciserver/TestRunPersistenceService.java
@@ -24,14 +24,14 @@ public class TestRunPersistenceService {
 	private static final Logger LOGGER = LoggerFactory.getLogger(TestRunPersistenceService.class);
 
 	boolean createFolder() {
-        try {
-            Files.createDirectories(Path.of(FOLDER));
+		try {
+			Files.createDirectories(Path.of(FOLDER));
 			return true;
-        } catch (IOException e) {
+		} catch (IOException e) {
 			LOGGER.error("Error creating '{}' folder ; {}", FOLDER, e.getMessage());
-            throw new RuntimeException(e);
-        }
-    }
+			throw new RuntimeException(e);
+		}
+	}
 
 	List<String> getAllJsonFilesInFolder() {
 		File[] files = new File(FOLDER).listFiles();
@@ -101,7 +101,7 @@ public class TestRunPersistenceService {
 	 * @return true if the test run was saved successfully, false otherwise
 	 */
 	public boolean save(TestRunModel testRun) {
-		if(!createFolder()) {
+		if (!createFolder()) {
 			return false;
 		}
 		String filename = FOLDER + "/" + testRun.commitSHA() + ".json";

--- a/src/test/java/app/ciserver/TestRunPersistenceServiceTest.java
+++ b/src/test/java/app/ciserver/TestRunPersistenceServiceTest.java
@@ -116,10 +116,12 @@ class TestRunPersistenceServiceTest {
 		TestRunModel testRun = new TestRunModel(date, "success", "COMMITHASH", "main", "name", "Build success");
 		String expectedFileContents = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(testRun);
 		// We simulate writing to disk producing an IOException
+		doReturn(true).when(testRunPersistenceService).createFolder();
 		doThrow(IOException.class).when(testRunPersistenceService).writeToFile(anyString(), anyString());
 
 		boolean result = testRunPersistenceService.save(testRun);
 
+		verify(testRunPersistenceService).createFolder();
 		verify(testRunPersistenceService).writeToFile("testRuns/COMMITHASH.json", expectedFileContents);
 		assertFalse(result);
 	}
@@ -132,10 +134,12 @@ class TestRunPersistenceServiceTest {
 	void testSaveSuccess() throws IOException {
 		TestRunModel testRun = new TestRunModel(date, "success", "COMMITHASH", "main", "name", "Build success");
 		String expectedFileContents = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(testRun);
+		doReturn(true).when(testRunPersistenceService).createFolder();
 		doNothing().when(testRunPersistenceService).writeToFile(anyString(), anyString());
 
 		boolean result = testRunPersistenceService.save(testRun);
 
+		verify(testRunPersistenceService).createFolder();
 		verify(testRunPersistenceService).writeToFile("testRuns/COMMITHASH.json", expectedFileContents);
 		assertTrue(result);
 	}


### PR DESCRIPTION
When you call TestRunPersistenceService.save(...), it now creates the testRuns folder if it does not exist.

Closes #58 