### PR TITLE
Fix: #63 Correct API URL

### DIFF
--- a/src/main/java/app/ciserver/NotificationService.java
+++ b/src/main/java/app/ciserver/NotificationService.java
@@ -119,7 +119,8 @@ public class NotificationService {
 			String json = new ObjectMapper().writeValueAsString(bodyParams);
 			HttpClient client = clientBuilder().build();
 			HttpRequest request = requestBuilder()
-					.uri(URI.create(pathParams.repository().fullName() + "/statuses/" + pathParams.after()))
+					.uri(URI.create("https://api.github.com/repos/" + pathParams.repository().fullName() + "/statuses/"
+							+ pathParams.after()))
 					.header("Accept", "application/vnd.github+json")
 					.header("Authorization", "Bearer " + getGithubToken()).header("X-GitHub-Api-Version", "2022-11-28")
 					.timeout(Duration.ofMinutes(2)).POST(BodyPublishers.ofString(json)).build();

--- a/src/test/java/app/ciserver/NotificationServiceTest.java
+++ b/src/test/java/app/ciserver/NotificationServiceTest.java
@@ -110,7 +110,7 @@ class NotificationServiceTest {
 
 		spyNotificationService.requestWrapper(bodyParams, pathParams);
 
-		verify(mockedRequestBuilder).uri(URI.create("FullName/statuses/sha23"));
+		verify(mockedRequestBuilder).uri(URI.create("https://api.github.com/repos/FullName/statuses/sha23"));
 		verify(mockedRequestBuilder).header("Accept", "application/vnd.github+json");
 		verify(mockedRequestBuilder).header("Authorization", "Bearer " + spyNotificationService.getGithubToken());
 		verify(mockedRequestBuilder).header("X-GitHub-Api-Version", "2022-11-28");


### PR DESCRIPTION
The notification service should now send the request to the correct URL. Small changes to requestWrapper test where it verifies the url created for the request builder.


Closes #63. 