### PR TITLE
Fix: #69 change builds url from Builds to builds

### DIFF
--- a/src/main/java/app/ciserver/Main.java
+++ b/src/main/java/app/ciserver/Main.java
@@ -34,8 +34,8 @@ public class Main {
 				testRunPersistenceService);
 
 		app.post("/hook", hookController::hookHandler);
-		app.get("/Builds", testRunController::testRunListHandler);
-		app.get("/Builds/{commitSHA}", testRunController::testRunDetailHandler);
+		app.get("/builds", testRunController::testRunListHandler);
+		app.get("/builds/{commitSHA}", testRunController::testRunDetailHandler);
 
 	}
 


### PR DESCRIPTION
Changed the build url from Builds to builds, spelling error was missed.

Closes #69 